### PR TITLE
Fix onMediaStatusUpdate on Android when queueData is null

### DIFF
--- a/src/cast.android.ts
+++ b/src/cast.android.ts
@@ -811,8 +811,6 @@ export class CastButton extends CastButtonBase {
           break;
       }
 
-      const queueData = mediaStatus.getQueueData();
-
       status = {
         activeTrackIds,
         playerState,
@@ -827,7 +825,14 @@ export class CastButton extends CastButtonBase {
         loadingItemID: mediaStatus.getLoadingItemId(),
         preloadedItemID: mediaStatus.getPreloadedItemId(),
 
-        queueData: {
+        queueData: null,
+
+        queueItemCount: mediaStatus.getQueueItemCount(),
+      };
+
+      const queueData = mediaStatus.getQueueData();
+      if (queueData) {
+        status.queueData = {
           name: queueData.getName(),
           queueID: queueData.getQueueId(),
           queueType: queueTypeEnumToString(queueData.getQueueType()),
@@ -836,9 +841,8 @@ export class CastButton extends CastButtonBase {
           // containerMetadata: getContainerMetadata(),
           startIndex: queueData.getStartIndex(),
           startTime: queueData.getStartTime(),
-        },
-        queueItemCount: mediaStatus.getQueueItemCount(),
-      };
+        };
+      }
     }
     this.sendEvent(CastButtonBase.castEvent, {
       eventName: CastEvent.onMediaStatusChanged,


### PR DESCRIPTION
In my case, `queueData` is always null so it crashes the app every time `onMediaStatusUpdate` is called. I added this little check to avoid the crash.

I was not able to use the `publish/pack.sh` script. It fails every time because it does not find the `build.angular` npm script. I think there is something wrong with the `cd ..` line before the angular build part. I tried to remove it but it fails anyway after that.

```
Error: The Angular Compiler requires TypeScript >=3.9.2 and <4.1.0 but 4.1.3 was found instead.
```

Maybe TypeScript version should be pinned in package.json and `npm ci` should be used instead of `npm i` in pack.sh script?

Let me know if I can do something on my side to help you publish a new version!

